### PR TITLE
Embed stun request within the agent, to find the port binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ build-stun:  dist ## Build stun client
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -o ./dist ./hack/stun-client
 
+.PHONY: build-udpserver
+build-udpserver:  dist ## Build udp server
+	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
+	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -o ./dist ./hack/udpserver
+
+.PHONY: build-udpclient
+build-udpclient:  dist ## Build udp server
+	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
+	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -o ./dist ./hack/udpclient
+
 .PHONY: fire-stun
 fire-stun:   ## Run stun client
 	$(CMD_PREFIX) ./dist/stun-client -source-port 55380 -check-symmetric

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,8 @@ func qnetRun(cCtx *cli.Context, logger *zap.Logger) error {
 	qmesh, err := quicmesh.NewQuicMesh(
 		logger.Sugar(),
 		cCtx.String("config-file"),
+		cCtx.Bool("disable-client"),
+		cCtx.Bool("disable-server"),
 	)
 	if err != nil {
 		logger.Fatal(err.Error())
@@ -99,6 +101,20 @@ func main() {
 				Value:    "",
 				Usage:    "Quic network configuration file",
 				Required: true,
+				Category: tunnelOptions,
+			},
+			&cli.BoolFlag{
+				Name:     "disable-client",
+				Value:    false,
+				Usage:    "Disable client function",
+				Required: false,
+				Category: tunnelOptions,
+			},
+			&cli.BoolFlag{
+				Name:     "disable-server",
+				Value:    false,
+				Usage:    "Disable server function",
+				Required: false,
 				Category: tunnelOptions,
 			},
 			&cli.StringFlag{

--- a/hack/udpclient/udpclient.go
+++ b/hack/udpclient/udpclient.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	// Create a UDP address to connect to
+	addr, err := net.ResolveUDPAddr("udp", "")
+	if err != nil {
+		fmt.Println("Error resolving address:", err)
+		return
+	}
+
+	fmt.Println("addr is ", addr.String())
+
+	d := net.Dialer{
+		Control:   Control,
+		LocalAddr: addr,
+		Timeout:   time.Duration(0),
+	}
+
+	// Create a UDP connection to the server
+	//conn, err := net.DialUDP("udp", nil, addr)
+	conn, err := d.Dial("udp", "172.31.28.175:55380")
+	if err != nil {
+		fmt.Println("Error connecting:", err)
+		return
+	}
+
+	fmt.Println("conn is ", conn.LocalAddr(), conn.RemoteAddr())
+
+	defer conn.Close()
+
+	// Send a message to the server
+	message := []byte("Hello, server!")
+	_, err = conn.Write(message)
+	if err != nil {
+		fmt.Println("Error sending message:", err)
+		return
+	}
+
+	//print message
+	fmt.Println("message is ", string(message))
+
+	// Create a buffer to store the response
+	buffer := make([]byte, 1500)
+
+	// Read the response from the server
+	n, err := conn.Read(buffer)
+	if err != nil {
+		fmt.Println("Error reading response:", err)
+		return
+	}
+
+	// Print the response from the server
+	fmt.Println("Response from server:", string(buffer[:n]))
+}
+
+// Control is a Dialer.Control function for setting SO_REUSEADDR and SO_REUSEPORT.
+func Control(network, address string, c syscall.RawConn) (err error) {
+	controlErr := c.Control(func(fd uintptr) {
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if err != nil {
+			return
+		}
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	})
+	if controlErr != nil {
+		err = controlErr
+	}
+	return
+}

--- a/hack/udpserver/udpserver.go
+++ b/hack/udpserver/udpserver.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func main() {
+	// Create a UDP address to listen on
+	addr, err := net.ResolveUDPAddr("udp4", ":55380")
+	if err != nil {
+		fmt.Println("Error resolving UDP address:", err)
+		return
+	}
+
+	fmt.Println("addr is ", addr.IP, addr.Port)
+
+	// Create a UDP connection to listen for incoming packets
+	conn, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		fmt.Println("Error listening on UDP:", err)
+		return
+	}
+
+	//print conn4
+	fmt.Println("conn is ", conn.LocalAddr(), conn.RemoteAddr())
+
+	defer conn.Close()
+
+	// Create a buffer to store incoming data
+	buffer := make([]byte, 1500)
+
+	fmt.Println("UDP server is running. Listening on :55380")
+
+	// Continuously listen for incoming packets on both connections
+	for {
+		// Read data from the UDP4 connection into the buffer
+		n, addr, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			fmt.Println("Error reading from UDP4 connection:", err)
+			return
+		}
+
+		// Print the received message
+		fmt.Printf("Received message from %s (UDP): %s\n", addr.String(), string(buffer[:n]))
+
+		// Send a response back to the client on the UDP4 connection
+		response := []byte("Message received (UDP4)!")
+		_, err = conn.WriteToUDP(response, addr)
+		if err != nil {
+			fmt.Println("Error sending response (UDP4):", err)
+			return
+		}
+
+	}
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -62,7 +62,7 @@ func (c *Client) Dial() error {
 		NextProtos:         []string{"some-proto"},
 	}
 
-	// udpAddr, err := net.ResolveUDPAddr("udp", c.Addr)
+	// udpAddr, err := net.ResolveUDPAddr("udp", c.addr)
 	// if err != nil {
 	// 	return err
 	// }
@@ -72,9 +72,8 @@ func (c *Client) Dial() error {
 	// 	return err
 	// }
 
-	// conn, err := quic.Dial(udpConn, udpAddr, c.Addr, tlsConf, &quic.Config{
-	// 	MaxIdleTimeout:  60,
-	// 	KeepAlivePeriod: 30,
+	// conn, err := quic.Dial(udpConn, udpAddr, c.addr, tlsConf, &quic.Config{
+	// 	KeepAlivePeriod: 10,
 	// 	EnableDatagrams: true,
 	// })
 

--- a/internal/quicmesh.go
+++ b/internal/quicmesh.go
@@ -33,20 +33,32 @@ type QuicMesh struct {
 	// QuicNet state data
 	localIf *water.Interface
 
-	connections map[string]quic.Connection
-	clients     map[string]*Client
+	//NAT port binding determined through stun request
+	portBinding string
+
+	//Flag to indicate if node is behind Symmetric NAT
+	symmetricNAT bool
+
+	connections   map[string]quic.Connection
+	clients       map[string]*Client
+	disableClient bool
+	disableServer bool
 }
 
 // NewQuicMesh creates a new QuicMesh
 func NewQuicMesh(logger *zap.SugaredLogger,
-	configFile string) (*QuicMesh, error) {
+	configFile string,
+	disableClient bool,
+	disableServer bool) (*QuicMesh, error) {
 
 	qn := &QuicMesh{
-		qc:          &QuicConf{},
-		logger:      logger,
-		configFile:  configFile,
-		connections: make(map[string]quic.Connection),
-		clients:     make(map[string]*Client),
+		qc:            &QuicConf{},
+		logger:        logger,
+		configFile:    configFile,
+		connections:   make(map[string]quic.Connection),
+		clients:       make(map[string]*Client),
+		disableClient: disableClient,
+		disableServer: disableServer,
 	}
 	return qn, nil
 }
@@ -65,8 +77,14 @@ func (qn *QuicMesh) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		return err
 	}
 
+	//find port binding
+	if !qn.disableServer {
+		qn.findPortBinding()
+	}
+
 	// Start the server
-	qn.setupTunnel(wg)
+	qn.setupTunnel(wg, qn.disableClient, qn.disableServer)
+
 	qn.enableTrafficForwarding()
 	return nil
 }
@@ -80,7 +98,7 @@ func (qn *QuicMesh) createTunIface() error {
 	// Create a TUN interface
 	iface, err := water.New(water.Config{DeviceType: water.TUN})
 	if err != nil {
-		return fmt.Errorf("Failed to create TUN interface: %w", err)
+		return fmt.Errorf("failed to create Tun interface: %w", err)
 	}
 	qn.logger.Debugf("TUN interface created: %s", iface.Name())
 
@@ -88,14 +106,14 @@ func (qn *QuicMesh) createTunIface() error {
 	tunnelIPStr := fmt.Sprintf("%s/24", qn.qc.nodeInterface.localEndpoint)
 	cmd := exec.Command("ip", "addr", "add", tunnelIPStr, "dev", iface.Name())
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Failed to assign IP address to TUN interface: %w", err)
+		return fmt.Errorf("failed to assign IP address to TUN interface: %w", err)
 	}
 	qn.logger.Debugf("IP address assigned to TUN interface")
 
 	// Up the TUN interface
 	cmd = exec.Command("ip", "link", "set", "dev", iface.Name(), "up")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Failed to change the state to UP for the TUN interface: %v", err)
+		return fmt.Errorf("failed to change the state to UP for the TUN interface: %v", err)
 	}
 	qn.logger.Debugf("TUN interface %s is up and running", iface.Name())
 	qn.localIf = iface
@@ -103,70 +121,100 @@ func (qn *QuicMesh) createTunIface() error {
 	return nil
 }
 
-func (qn *QuicMesh) setupTunnel(wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		// server mode
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+func (qn *QuicMesh) findPortBinding() (string, error) {
 
-		localipPortStr := fmt.Sprintf("%s:%d", qn.qc.nodeInterface.localNodeIP, qn.qc.nodeInterface.listenPort)
-		qn.logger.Infof("Starting server on %s", localipPortStr)
-		s := NewServer(localipPortStr, qn.localIf, qn.logger)
-		s.SetHandler(func(c packetContext) error {
-			msg := c.Data
-			qn.logger.Debugf("Client [ %s ] sent a message [ %v ] over client initiated connection", c.RemoteAddr().String(), msg)
-			c.localIf.Write(c.Data)
-			return nil
-		})
-		qn.logger.Fatal(s.StartServer(ctx, qn.connections, wg))
-	}()
+	isSymmetric, err := IsSymmetricNAT(qn.qc.nodeInterface.listenPort)
+	if err != nil {
+		qn.logger.Error(err)
+	}
+	if isSymmetric {
+		qn.logger.Warn("Node is behind Symmetric NAT")
+		return "", fmt.Errorf("node is behind Symmetric NAT")
+	}
 
-	wg.Wait()
+	res, err := GetPortBinding(qn.qc.nodeInterface.listenPort)
+	if err != nil {
+		qn.logger.Fatalf("stun request failed: %v", err)
+	}
+	qn.logger.Infof("Port binding returned by STUN request: %s", res)
+	return res, nil
+}
 
-	//range over all peers and create client connections
-	for _, peer := range qn.qc.peers {
-		qn.logger.Debugf("Starting client for peer %s", peer.endpoint)
-		go func(peer Peer) {
+func (qn *QuicMesh) setupTunnel(wg *sync.WaitGroup, disableClient bool, disableServer bool) {
+	if !disableServer {
+		wg.Add(1)
+		go func() {
+			// server mode
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			c := NewClient(peer.endpoint, qn.qc.nodeInterface.localNodeIP, qn.qc.nodeInterface.listenPort, qn.localIf, qn.logger)
-
-			//split endpoint to get ip and port
-			host, _, err := net.SplitHostPort(peer.endpoint)
-			if err != nil {
-				qn.logger.Fatalf("Failed to split host and port: %v", err)
-			}
-
-			err = RetryOperation(ctx, retryInterval, retries, func() error {
-				if conn, ok := qn.connections[host]; ok {
-					qn.logger.Infof("Connection already exists for peer endpoint %s", peer.endpoint)
-					c.SetConnection(conn)
-					return nil
-				}
-				qn.logger.Debugf("No existing connection to the peer endpoint %s.", peer.endpoint)
-
-				err := c.Dial()
-				if err != nil {
-					qn.logger.Debugf("Failed to dial: %v", err)
-					qn.logger.Warnf("Retrying to dial %s", peer.endpoint)
-					return err
-				}
-				qn.logger.Infof("Dialed new connection to peer endpoint %s.", peer.endpoint)
-				c.AttachHandler(func(c packetContext) error {
-					msg := c.Data
-					qn.logger.Debugf("Client [ %s ] sent a message [ %v ] over server initiated connection", c.RemoteAddr().String(), msg)
-					c.localIf.Write(c.Data)
-					return nil
-				})
+			localipPortStr := fmt.Sprintf("%s:%d", qn.qc.nodeInterface.localNodeIP, qn.qc.nodeInterface.listenPort)
+			qn.logger.Infof("Starting server on %s", localipPortStr)
+			s := NewServer(localipPortStr, qn.localIf, qn.logger)
+			s.SetHandler(func(c packetContext) error {
+				msg := c.Data
+				qn.logger.Debugf("Client [ %s ] sent a message [ %v ] over client initiated connection", c.RemoteAddr().String(), msg)
+				c.localIf.Write(c.Data)
 				return nil
 			})
-			if err != nil {
-				qn.logger.Fatalf("Peer is not reachable or : %v", err)
-			}
-			qn.clients[peer.allowedIPs[0]] = c
-		}(peer)
+			qn.logger.Fatal(s.StartServer(ctx, qn, wg))
+		}()
+		wg.Wait()
+	}
+
+	if !disableClient {
+
+		//range over all peers and create client connections
+		for _, peer := range qn.qc.peers {
+			qn.logger.Debugf("Starting client for peer %s", peer.endpoint)
+			go func(peer Peer) {
+
+				_, ok := qn.clients[peer.allowedIPs[0]]
+				if ok {
+					qn.logger.Infof("Client already exists for peer %s [ %s ]", peer.endpoint, peer.allowedIPs[0])
+					return
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				c := NewClient(peer.endpoint, qn.qc.nodeInterface.localNodeIP, qn.qc.nodeInterface.listenPort, qn.localIf, qn.logger)
+
+				//split endpoint to get ip and port
+				host, _, err := net.SplitHostPort(peer.endpoint)
+				if err != nil {
+					qn.logger.Fatalf("Failed to split host and port: %v", err)
+				}
+
+				err = RetryOperation(ctx, retryInterval, retries, func() error {
+					if conn, ok := qn.connections[host]; ok {
+						qn.logger.Infof("Connection already exists for peer endpoint %s", peer.endpoint)
+						c.SetConnection(conn)
+						return nil
+					}
+					qn.logger.Debugf("No existing connection to the peer endpoint %s.", peer.endpoint)
+
+					err := c.Dial()
+					if err != nil {
+						qn.logger.Debugf("Failed to dial: %v", err)
+						qn.logger.Warnf("Retrying to dial %s", peer.endpoint)
+						return err
+					}
+					qn.logger.Infof("Dialed new connection to peer endpoint %s.", peer.endpoint)
+					c.AttachHandler(func(c packetContext) error {
+						msg := c.Data
+						qn.logger.Debugf("Client [ %s ] sent a message [ %v ] over server initiated connection", c.RemoteAddr().String(), msg)
+						c.localIf.Write(c.Data)
+						return nil
+					})
+					return nil
+				})
+				if err != nil {
+					qn.logger.Fatalf("Peer is not reachable or : %v", err)
+				}
+				qn.clients[peer.allowedIPs[0]] = c
+			}(peer)
+		}
 	}
 }
 
@@ -192,6 +240,7 @@ func (qn *QuicMesh) enableTrafficForwarding() error {
 				if err != nil {
 					qn.logger.Errorf("failed to send client message: %v", err)
 				}
+				//check if dstIp is in the Con
 			} else {
 				qn.logger.Debugf("No client connection found for destination IP %s", dstIP.String())
 			}

--- a/internal/stun.go
+++ b/internal/stun.go
@@ -1,0 +1,105 @@
+package quicmesh
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/libp2p/go-reuseport"
+	"github.com/pion/stun"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	stunServer1 = "stun1.l.google.com:19302"
+	stunServer2 = "stun2.l.google.com:19302"
+)
+
+// IsSymmetricNAT attempts to infer if the node is behind a symmetric
+// nat device by querying two STUN servers. If the requests return
+// different ports, then it is likely the node is behind a symmetric nat.
+func IsSymmetricNAT(sourcePort int) (bool, error) {
+	firstStun, err := StunRequest(stunServer1, sourcePort)
+	if err != nil {
+		return false, fmt.Errorf("failed to query the STUN server %s", stunServer1)
+	}
+	log.Infof("STUN Result from %s => [ %s ]", stunServer1, firstStun)
+	secondStun, err := StunRequest(stunServer2, sourcePort)
+	if err != nil {
+		return false, fmt.Errorf("failed to query the STUN server %s", stunServer1)
+	}
+	if firstStun != secondStun {
+		return true, nil
+	}
+	log.Infof("STUN Result from %s => [ %s ]", stunServer1, secondStun)
+
+	return false, nil
+}
+
+// GetPortBinding returns the NAT port binding (IP:port) of the node
+func GetPortBinding(sourcePort int) (string, error) {
+	stunServer := stunServer1
+	res, err := StunRequest(stunServer, sourcePort)
+	if err != nil {
+		return "", fmt.Errorf("stun request failed: %v", err)
+	}
+	return res, nil
+}
+
+// StunRequest initiate a connection to a STUN server sourced from the wg src port
+func StunRequest(stunServer string, srcPort int) (string, error) {
+
+	log.Debugf("dialing stun server %s", stunServer)
+
+	conn, err := reuseport.Dial("udp4", fmt.Sprintf(":%d", srcPort), stunServer)
+	if err != nil {
+		log.Errorf("stun dialing timed out %v", err)
+		return "", fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)
+	}
+
+	defer conn.Close()
+	stunResults, err := stunDialer(&conn)
+	if err != nil {
+		return "", fmt.Errorf("stun dialing timed out %w", err)
+	}
+	return stunResults, nil
+}
+
+func stunDialer(conn *net.Conn) (string, error) {
+	c, err := stun.NewClient(*conn)
+	if err != nil {
+		log.Errorf("%v", err)
+	}
+	var xorAddr stun.XORMappedAddress
+	if err = c.Do(stun.MustBuild(stun.TransactionID, stun.BindingRequest), func(res stun.Event) {
+		if res.Error != nil {
+			log.Println(res.Error)
+			return
+		}
+		if getErr := xorAddr.GetFrom(res.Message); getErr != nil {
+			log.Println(getErr)
+			if err := c.Close(); err != nil {
+				log.Println(err)
+				return
+			}
+			return
+		}
+		log.Debugf("Stun address and port is: %s:%d", xorAddr.IP, xorAddr.Port)
+
+	}); err != nil {
+		return "", err
+	}
+	if err := c.Close(); err != nil {
+		return "", err
+	}
+
+	if xorAddr.IP == nil {
+		return "", fmt.Errorf("no response")
+	}
+	stunAddress := net.JoinHostPort(xorAddr.IP.String(), strconv.Itoa(xorAddr.Port))
+	if err != nil {
+		return "", err
+	}
+
+	return stunAddress, nil
+}


### PR DESCRIPTION
Also it adds,
Add options to disable client or server function

udpserver and udpclient code to debug port bindings.

Reuse the connection if already exist, that enables tunnel connection if atleast one endpoint allows udp traffic.